### PR TITLE
feat: 최근 컨텍스트 조회에 프로젝트 설명 추가 및 join 조건 강화

### DIFF
--- a/src/main/java/com/moa/moa_backend/domain/scrap/dto/ScrapRecentContextResponse.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/dto/ScrapRecentContextResponse.java
@@ -9,6 +9,7 @@ public record ScrapRecentContextResponse(
     public record Item(
             Long projectId,
             String projectName,
+            String projectDescription,
             String lastStage,
             Instant lastCapturedAt
     ) {}

--- a/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapRepository.java
@@ -64,17 +64,21 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     @Query(value = """
         select x.project_id   as projectId,
                x.project_name as projectName,
+               x.project_description as projectDescription,
                x.stage        as lastStage,
                x.captured_at  as lastCapturedAt
         from (
             select distinct on (s.project_id)
                    s.project_id,
                    p.project_name,
+                   p.project_description,
                    s.stage,
                    s.captured_at,
                    s.scrap_id
             from scraps s
-            join projects p on p.project_id = s.project_id
+            join projects p
+              on p.project_id = s.project_id
+             and p.user_id    = s.user_id
             where s.user_id = :userId
             order by s.project_id, s.captured_at desc, s.scrap_id desc
         ) x
@@ -86,6 +90,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     interface RecentContextRow {
         Long getProjectId();
         String getProjectName();
+        String getProjectDescription();
         String getLastStage();
         Instant getLastCapturedAt();
     }

--- a/src/main/java/com/moa/moa_backend/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/service/ScrapService.java
@@ -195,6 +195,7 @@ public class ScrapService {
                         .map(r -> new ScrapRecentContextResponse.Item(
                                 r.getProjectId(),
                                 r.getProjectName(),
+                                r.getProjectDescription(),
                                 r.getLastStage(),
                                 r.getLastCapturedAt()
                         ))


### PR DESCRIPTION
### 배경 / 목적
현재 GET /api/scraps/recent-context API는프로젝트별 최신 스크랩 기준 컨텍스트를 반환하지만,
프론트에서 프로젝트 카드/컨텍스트 영역에 프로젝트 설명을 함께 표시해야함
이에 따라 API 응답에 projectDescription 필드를 포함하도록 수정한다.

### 변경 사항 요약
- recent-context 응답에 projectDescription 추가
- scraps + projects 조인을 통해 프로젝트 설명 조회
- API 명세 및 DTO, Repository, Service 로직 수정

#### 비고

- DB 스키마 변경 없음
- 기존 API 사용자 영향 없음 (Response 필드 추가만 발생)