### PR TITLE
hotfix: 프로젝트 존재 시 Draft 추천 projectId 정합성 보장

### DIFF
--- a/src/main/java/com/moa/moa_backend/domain/draft/llm/impl/GeminiClient.java
+++ b/src/main/java/com/moa/moa_backend/domain/draft/llm/impl/GeminiClient.java
@@ -170,9 +170,12 @@ public class GeminiClient {
                 
                 제약:
                 - stage는 반드시 fixedStages 중 하나여야 한다.
-                - projectId는 projects 목록에 있는 값만 선택할 수 있다.
-                - 적절한 프로젝트가 없다면 projectId는 null로 둬라.
-                - subtitle은 scrapText를 15~25자 내로 요약해라. **가능하면 null을 쓰지 마라.**
+                - projects가 비어있으면 projectId는 null로 출력하라.
+                - projects가 1개 이상이면 projectId는 반드시 projects 중 하나(number)여야 하며 null 금지.
+                - projects가 1개 이상이고 recentContext.projectId가 null이 아니면, projectId는 반드시 recentContext.projectId로 출력하라 (scrapText가 매우 명확히 다른 프로젝트를 가리키는 경우만 예외).
+                - subtitle은 scrapText를 15~25자 내로 요약해라. 가능하면 null을 쓰지 마라.
+                - 반드시 JSON 객체 1개만 출력하고, 앞뒤로 어떤 문자도 붙이지 마라.
+                
                 
                 입력:
                 projects=%s
@@ -184,6 +187,7 @@ public class GeminiClient {
 
                 출력(JSON만):
                 {"projectId": number|null, "stage": string, "subtitle": string|null}
+                ※ 단, projects가 1개 이상이면 projectId는 반드시 number여야 한다(null 금지).
                 """.formatted(
                 projectsStr,
                 recentStr,

--- a/src/main/java/com/moa/moa_backend/domain/draft/llm/impl/GeminiLlmAdapter.java
+++ b/src/main/java/com/moa/moa_backend/domain/draft/llm/impl/GeminiLlmAdapter.java
@@ -36,7 +36,7 @@ public class GeminiLlmAdapter implements LlmRecommendationPort {
 
         // 1. 사전검증 : fixedStages가 있어야만 추천 가능 없으면 불가능
         if (command.fixedStages() == null || command.fixedStages().isEmpty()) {
-            throw new IllegalStateException("fixedStages must not be empty");
+            throw new ApiException(ErrorCode.DRAFT_RECOMMENDATION_CONFIG_INVALID);
         }
 
         try {

--- a/src/main/java/com/moa/moa_backend/domain/draft/service/DraftService.java
+++ b/src/main/java/com/moa/moa_backend/domain/draft/service/DraftService.java
@@ -11,6 +11,7 @@ import com.moa.moa_backend.domain.scrap.service.ScrapService;
 import com.moa.moa_backend.global.error.ApiException;
 import com.moa.moa_backend.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ import java.util.List;
  * 확장프로그램에서 스크랩한 내용을 임시 저장하고 LLM을 통해 프로젝트/단계/소제목을 추천받은 후
  * 사용자 확정 시 실제 Scrap으로 변환하는 역할
  */
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class DraftService {
@@ -89,6 +91,18 @@ public class DraftService {
 
         DraftRecommendation rec = llmRecommendationPort.recommend(command);
 
+        if (rec == null) {
+            log.error("[DRAFT] recommendation is null: userId={}, projectsSize={}, recentProjectId={}",
+                    userId,
+                    projects.size(),
+                    recentContext == null ? null : recentContext.projectId()
+            );
+            throw new ApiException(ErrorCode.DRAFT_RECOMMENDATION_INVALID);
+        }
+
+        boolean hasProjects = !projects.isEmpty();
+
+
         // 5) drafts 저장
         Draft saved = draftRepository.save(Draft.create(
                 userId,
@@ -115,7 +129,6 @@ public class DraftService {
 
     }
 
-//TODO 아직 최종 저장하는걸 안만들어서 드래프트 만들고 조회하려고 일단 만들어두고, 나중에 필요없으면 주석처리할 예정
     /**
      * 최신 드래프트 조회
      *

--- a/src/main/java/com/moa/moa_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/moa/moa_backend/global/error/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     DRAFT_EXPIRED(HttpStatus.GONE, "DRF_410", "드래프트가 만료되었습니다."),
     DRAFT_ALREADY_COMMITTED(HttpStatus.CONFLICT, "DRF_409", "이미 처리된 드래프트입니다."),
     DRAFT_RECOMMENDATION_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "DRF_500", "드래프트 추천 결과가 유효하지 않습니다."),
+    DRAFT_RECOMMENDATION_CONFIG_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "DRF_500", "드래프트 추천 설정이 유효하지 않습니다."),
 
     //scraps
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCP_404", "스크랩을 찾을 수 없습니다."),

--- a/src/main/java/com/moa/moa_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/moa/moa_backend/global/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "DRF_404", "드래프트를 찾을 수 없습니다."),
     DRAFT_EXPIRED(HttpStatus.GONE, "DRF_410", "드래프트가 만료되었습니다."),
     DRAFT_ALREADY_COMMITTED(HttpStatus.CONFLICT, "DRF_409", "이미 처리된 드래프트입니다."),
+    DRAFT_RECOMMENDATION_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "DRF_500", "드래프트 추천 결과가 유효하지 않습니다."),
 
     //scraps
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCP_404", "스크랩을 찾을 수 없습니다."),


### PR DESCRIPTION
> 본 이슈는 LLM 응답 품질 문제가 아니라 서버 정책 검증 누락으로 인한 버그
LLM은 “추천”만 수행하고, 정합성 보장은 서버 책임이라는 방향에서 설계 정리됨

 ### 문제 요약
프로젝트가 1개 이상 존재하는 사용자임에도 Draft 생성 시 LLM 추천 결과의 `projectId`가 null로 내려오는 경우가 발생

---

### 원인
- LLM이 입력 텍스트 길이/맥락 부족 등의 이유로
  `stage`, `subtitle`만 추천하고 `projectId`를 누락하는 케이스 존재
- 서버 단에서 LLM 결과에 대한 **정합성 검증 및 보정 로직이 부족했음**
- LLM 응답을 신뢰하고 그대로 Draft 추천 결과로 사용하고 있었음

---

### 해결 내용
### 1. 서버 정책 기반 정규화 로직 추가
Gemini LLM 응답에 대해 아래 순서로 `projectId`를 보정:

1. LLM이 반환한 `projectId`가 유효하면 사용
2. `recentContext.projectId`가 있으면 해당 값 사용
3. 프로젝트가 1개뿐인 경우 해당 프로젝트로 강제 지정
4. 위 조건을 모두 만족하지 못하면 **정책 위반으로 예외 처리**

```text
프로젝트가 존재하는데 projectId를 결정하지 못하는 경우는 서버 오류
