### PR TITLE
feat: 작업 요약 자동 스케줄러 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// html to markdown
 	implementation 'com.vladsch.flexmark:flexmark-html2md-converter:0.64.8'

--- a/src/main/java/com/moa/moa_backend/MoaBackendApplication.java
+++ b/src/main/java/com/moa/moa_backend/MoaBackendApplication.java
@@ -2,7 +2,9 @@ package com.moa.moa_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class MoaBackendApplication {
 

--- a/src/main/java/com/moa/moa_backend/domain/digest/llm/StageDigestGeneratorPort.java
+++ b/src/main/java/com/moa/moa_backend/domain/digest/llm/StageDigestGeneratorPort.java
@@ -1,6 +1,6 @@
 package com.moa.moa_backend.domain.digest.llm;
 
-import com.moa.moa_backend.domain.scrap.repository.ScrapForDigestView;
+import com.moa.moa_backend.domain.scrap.repository.projection.ScrapForDigestView;
 
 import java.util.List;
 

--- a/src/main/java/com/moa/moa_backend/domain/digest/llm/impl/GeminiStageDigestAdapter.java
+++ b/src/main/java/com/moa/moa_backend/domain/digest/llm/impl/GeminiStageDigestAdapter.java
@@ -3,7 +3,7 @@ package com.moa.moa_backend.domain.digest.llm.impl;
 import com.moa.moa_backend.domain.digest.llm.StageDigestGeneratorPort;
 import com.moa.moa_backend.domain.digest.service.DigestInputNormalizer;
 import com.moa.moa_backend.domain.digest.service.DigestTextValidator;
-import com.moa.moa_backend.domain.scrap.repository.ScrapForDigestView;
+import com.moa.moa_backend.domain.scrap.repository.projection.ScrapForDigestView;
 import com.moa.moa_backend.global.llm.gemini.GeminiClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;

--- a/src/main/java/com/moa/moa_backend/domain/digest/scheduler/StageDigestAutoRefreshScheduler.java
+++ b/src/main/java/com/moa/moa_backend/domain/digest/scheduler/StageDigestAutoRefreshScheduler.java
@@ -1,0 +1,93 @@
+package com.moa.moa_backend.domain.digest.scheduler;
+
+import com.moa.moa_backend.domain.digest.service.StageDigestService;
+import com.moa.moa_backend.domain.scrap.repository.projection.DigestRefreshTarget;
+import com.moa.moa_backend.domain.scrap.repository.ScrapDigestQueryRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@Component
+public class StageDigestAutoRefreshScheduler {
+
+    private final ScrapDigestQueryRepository scrapDigestQueryRepository;
+    private final StageDigestService stageDigestService;
+
+    /**
+     * 스케줄러 중복 실행 방지 (단일 인스턴스 한정)
+     */
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    /**
+     * 하루에 최대 몇 개의 (userId, projectId, stage)를 처리할지
+     */
+    @Value("${moa.digest.auto-refresh.daily-limit:200}")
+    private int dailyLimit;
+
+    /**
+     * 최근 7일 내 활동한 stage만 대상
+     */
+    @Value("${moa.digest.auto-refresh.lookback-days:7}")
+    private int lookbackDays;
+
+    public StageDigestAutoRefreshScheduler(
+            ScrapDigestQueryRepository scrapDigestQueryRepository,
+            StageDigestService stageDigestService
+    ) {
+        this.scrapDigestQueryRepository = scrapDigestQueryRepository;
+        this.stageDigestService = stageDigestService;
+    }
+
+    /**
+     * 매일 1회 자동 refresh
+     * - KST 기준 새벽 4시
+     */
+    @Scheduled(cron = "${moa.digest.auto-refresh.cron:0 0 4 * * *}", zone = "Asia/Seoul")
+    public void runDailyRefresh() {
+
+        // 중복 실행 방지
+        if (!running.compareAndSet(false, true)) {
+            log.info("[DIGEST][SCHED] already running. skip.");
+            return;
+        }
+
+        Instant start = Instant.now();
+        int success = 0;
+        int fail = 0;
+
+        try {
+            Instant since = Instant.now().minus(Duration.ofDays(lookbackDays));
+
+            // 최근 활동 기준으로 대상 stage 목록 뽑기 (limit 적용)
+            List<DigestRefreshTarget> targets =
+                    scrapDigestQueryRepository.findRecentTargetsForAutoRefresh(since, dailyLimit);
+
+            log.info("[DIGEST][SCHED] start. targets={}, limit={}, lookbackDays={}",
+                    targets.size(), dailyLimit, lookbackDays);
+
+            // 순차 실행 + 한 건 실패해도 다음 건 진행
+            for (DigestRefreshTarget t : targets) {
+                try {
+                    stageDigestService.refresh(t.userId(), t.projectId(), t.stage());
+                    success++;
+                } catch (Exception e) {
+                    fail++;
+                    log.warn("[DIGEST][SCHED] refresh failed. userId={}, projectId={}, stage={}",
+                            t.userId(), t.projectId(), t.stage(), e);
+                }
+            }
+
+        } finally {
+            running.set(false);
+            long ms = Duration.between(start, Instant.now()).toMillis();
+            log.info("[DIGEST][SCHED] done. success={}, fail={}, elapsedMs={}", success, fail, ms);
+        }
+    }
+}

--- a/src/main/java/com/moa/moa_backend/domain/digest/service/StageDigestService.java
+++ b/src/main/java/com/moa/moa_backend/domain/digest/service/StageDigestService.java
@@ -152,6 +152,56 @@ public class StageDigestService {
 
             OffsetDateTime latestScrapKst = toKst(latestScrapInstant);
 
+            /**
+             * 변경 감지 -> 스킵
+             *
+             * 목적 :
+             * - 스크랩이 변했으 때만 llm 호출/db업데이트 수행
+             * - 변하지 않으면 여기서 바로 기존 digest 반환하여 비용과 부하 차단
+             *
+             */
+            Optional<StageDigest> existingOpt =
+                    stageDigestRepository.findByUserIdAndProjectIdAndStage(userId, projectId, stage);
+
+            if (existingOpt.isPresent()) {
+                StageDigest existing = existingOpt.get();
+
+                /**
+                 * upToDate 조건 설명:
+                 * - digest가 마지막으로 반영했던 스크랩 기준시각이 있고 현재 스크랩 최신시각이
+                 * - 그 이후가 아니라면 "변경 없음"으로 간주 : digest는 이미 최신 상태
+                 */
+                boolean upToDate =
+                        existing.getSourceLastCapturedAt() != null &&
+                                !latestScrapInstant.isAfter(existing.getSourceLastCapturedAt().toInstant());
+
+                if (upToDate) {
+                    log.info("[DIGEST] refresh skipped (up-to-date). userId={}, projectId={}, stage={}, latestScrap={}",
+                            userId, projectId, stage, latestScrapKst);
+
+                    String text = existing.getDigestText();
+                    boolean exists = (text != null && !text.isBlank());
+
+                    return new StageDigestResponse(
+                            new StageDigestResponse.ProjectDto(projectId, project.getName()),
+                            stage,
+                            exists ? text : null,
+                            new StageDigestResponse.Meta(
+                                    exists,
+                                    false, // 최신이므로 outdated=false
+                                    existing.getSourceLastCapturedAt(),
+                                    latestScrapKst,
+                                    existing.getUpdatedAt(),
+                                    DIGEST_VERSION
+                            )
+                    );
+                }
+            }
+
+            /**
+             * upToDate가 아니면(스크랩이 바뀌었으면) 여기부터 실제 갱신 수행
+             * 스크랩 목록 조회 -> 입력 정규화 -> (의미 있는 입력 확인) -> LLM -> DB upsert
+             */
             List<ScrapForDigestView> scraps = scrapForDigestRepository.findRecentForDigest(
                     userId, projectId, stage, PageRequest.of(0, INPUT_SCRAPS_LIMIT)
             );
@@ -182,6 +232,8 @@ public class StageDigestService {
                         latestScrapInstant, latestScrapKst
                 );
             }
+
+
 
             // =========================
             // LLM 호출 (트랜잭션 밖)

--- a/src/main/java/com/moa/moa_backend/domain/digest/service/StageDigestService.java
+++ b/src/main/java/com/moa/moa_backend/domain/digest/service/StageDigestService.java
@@ -152,25 +152,19 @@ public class StageDigestService {
 
             OffsetDateTime latestScrapKst = toKst(latestScrapInstant);
 
-            /**
-             * 변경 감지 -> 스킵
-             *
-             * 목적 :
-             * - 스크랩이 변했으 때만 llm 호출/db업데이트 수행
-             * - 변하지 않으면 여기서 바로 기존 digest 반환하여 비용과 부하 차단
-             *
-             */
+            //변경감지 -> 스킵
+            //스크랩이 변했을 때만 llm 호출/db업데이트 수행
+            //변하지 않으면 여기서 바로 기존 digest 반환하여 비용과 부하 차단
             Optional<StageDigest> existingOpt =
                     stageDigestRepository.findByUserIdAndProjectIdAndStage(userId, projectId, stage);
 
             if (existingOpt.isPresent()) {
                 StageDigest existing = existingOpt.get();
 
-                /**
-                 * upToDate 조건 설명:
-                 * - digest가 마지막으로 반영했던 스크랩 기준시각이 있고 현재 스크랩 최신시각이
-                 * - 그 이후가 아니라면 "변경 없음"으로 간주 : digest는 이미 최신 상태
-                 */
+
+                //upToDate 조건 설명:
+                // - digest가 마지막으로 반영했던 스크랩 기준시각이 있고 현재 스크랩 최신시각이
+                // - 그 이후가 아니라면 "변경 없음"으로 간주 : digest는 이미 최신 상태
                 boolean upToDate =
                         existing.getSourceLastCapturedAt() != null &&
                                 !latestScrapInstant.isAfter(existing.getSourceLastCapturedAt().toInstant());
@@ -198,10 +192,8 @@ public class StageDigestService {
                 }
             }
 
-            /**
-             * upToDate가 아니면(스크랩이 바뀌었으면) 여기부터 실제 갱신 수행
-             * 스크랩 목록 조회 -> 입력 정규화 -> (의미 있는 입력 확인) -> LLM -> DB upsert
-             */
+            //upToDate가 아니면(스크랩이 바뀌었으면) 여기부터 실제 갱신 수행
+            //스크랩 목록 조회 -> 입력 정규화 -> (의미 있는 입력 확인) -> LLM -> DB upsert
             List<ScrapForDigestView> scraps = scrapForDigestRepository.findRecentForDigest(
                     userId, projectId, stage, PageRequest.of(0, INPUT_SCRAPS_LIMIT)
             );
@@ -232,7 +224,6 @@ public class StageDigestService {
                         latestScrapInstant, latestScrapKst
                 );
             }
-
 
 
             // =========================

--- a/src/main/java/com/moa/moa_backend/domain/digest/service/StageDigestService.java
+++ b/src/main/java/com/moa/moa_backend/domain/digest/service/StageDigestService.java
@@ -8,7 +8,7 @@ import com.moa.moa_backend.domain.project.entity.Project;
 import com.moa.moa_backend.domain.project.repository.ProjectRepository;
 import com.moa.moa_backend.domain.scrap.repository.ScrapDigestQueryRepository;
 import com.moa.moa_backend.domain.scrap.repository.ScrapForDigestRepository;
-import com.moa.moa_backend.domain.scrap.repository.ScrapForDigestView;
+import com.moa.moa_backend.domain.scrap.repository.projection.ScrapForDigestView;
 import com.moa.moa_backend.global.error.ApiException;
 import com.moa.moa_backend.global.error.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
@@ -43,9 +43,9 @@ public class StageDigestService {
     private final ConcurrentHashMap<String, Boolean> inFlight = new ConcurrentHashMap<>();
 
     private String key(Long userId, Long projectId, String stage) {
-        return userId + ":" + projectId + ":" + stage;
+        String s = (stage == null) ? "" : stage.trim();
+        return userId + ":" + projectId + ":" + s;
     }
-
     public StageDigestService(
             ProjectRepository projectRepository,
             StageDigestRepository stageDigestRepository,

--- a/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapDigestQueryRepository.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapDigestQueryRepository.java
@@ -1,11 +1,13 @@
 package com.moa.moa_backend.domain.scrap.repository;
 
 import com.moa.moa_backend.domain.scrap.entity.Scrap;
+import com.moa.moa_backend.domain.scrap.repository.projection.DigestRefreshTarget;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.List;
 
 public interface ScrapDigestQueryRepository extends Repository<Scrap, Long> {
 
@@ -21,4 +23,30 @@ public interface ScrapDigestQueryRepository extends Repository<Scrap, Long> {
             @Param("projectId") Long projectId,
             @Param("stage") String stage
     );
+
+    /**
+     * 스케줄러용: 최근 활동한 (userId, projectId, stage) 목록 조회
+     * - since 이후 scraps만 대상
+     * - 각 그룹의 최신 captured_at 기준으로 최신순 정렬
+     * - limit 개수 제한
+     *
+     * NOTE: 테이블/컬럼명이 실제 DB와 다르면 여기 nativeQuery를 맞춰줘야 함.
+     * (예: table = scraps, column = captured_at/user_id/project_id/stage)
+     */
+    @Query(value = """
+        select
+            s.user_id as userId,
+            s.project_id as projectId,
+            s.stage as stage
+        from scraps s
+        where s.captured_at >= :since
+        group by s.user_id, s.project_id, s.stage
+        order by max(s.captured_at) desc
+        limit :limit
+        """, nativeQuery = true)
+    List<DigestRefreshTarget> findRecentTargetsForAutoRefresh(
+            @Param("since") Instant since,
+            @Param("limit") int limit
+    );
+
 }

--- a/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapDigestQueryRepository.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapDigestQueryRepository.java
@@ -29,9 +29,6 @@ public interface ScrapDigestQueryRepository extends Repository<Scrap, Long> {
      * - since 이후 scraps만 대상
      * - 각 그룹의 최신 captured_at 기준으로 최신순 정렬
      * - limit 개수 제한
-     *
-     * NOTE: 테이블/컬럼명이 실제 DB와 다르면 여기 nativeQuery를 맞춰줘야 함.
-     * (예: table = scraps, column = captured_at/user_id/project_id/stage)
      */
     @Query(value = """
         select

--- a/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapForDigestRepository.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/repository/ScrapForDigestRepository.java
@@ -1,6 +1,7 @@
 package com.moa.moa_backend.domain.scrap.repository;
 
 import com.moa.moa_backend.domain.scrap.entity.Scrap;
+import com.moa.moa_backend.domain.scrap.repository.projection.ScrapForDigestView;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -11,7 +12,7 @@ import java.util.List;
 public interface ScrapForDigestRepository extends Repository<Scrap, Long> {
 
     @Query("""
-        select new com.moa.moa_backend.domain.scrap.repository.ScrapForDigestView(
+        select new com.moa.moa_backend.domain.scrap.repository.projection.ScrapForDigestView(
             s.id, s.subtitle, s.memo, s.rawHtml, s.capturedAt
         )
         from Scrap s

--- a/src/main/java/com/moa/moa_backend/domain/scrap/repository/projection/DigestRefreshTarget.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/repository/projection/DigestRefreshTarget.java
@@ -1,0 +1,9 @@
+package com.moa.moa_backend.domain.scrap.repository.projection;
+
+public record DigestRefreshTarget (
+    Long userId,
+    Long projectId,
+    String stage
+) {}
+
+

--- a/src/main/java/com/moa/moa_backend/domain/scrap/repository/projection/ScrapForDigestView.java
+++ b/src/main/java/com/moa/moa_backend/domain/scrap/repository/projection/ScrapForDigestView.java
@@ -1,7 +1,6 @@
-package com.moa.moa_backend.domain.scrap.repository;
+package com.moa.moa_backend.domain.scrap.repository.projection;
 
 import java.time.Instant;
-import java.time.OffsetDateTime;
 
 /**
  * LLM 입력용으로 필요한 스크랩 필드만 추려온 Projection.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,5 +111,29 @@ moa:
   llm:
     gemini:
       api-key: ${MOA_LLM_GEMINI_API_KEY:dummy}
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  flyway:
+    enabled: false
+
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+moa:
+  llm:
+    gemini:
+      api-key: dummy
+      model: gemini-2.0-flash
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,12 @@ moa:
     timeout-ms: 3000
     digest-timeout-ms: 15000
 
+  digest:
+    auto-refresh:
+      cron: "0 0 4 * * *"        # 매일 04:00 KST
+      daily-limit: 200           # 하루 처리량 제한
+      lookback-days: 7           # 최근 7일 활동 stage만 대상
+
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,29 +111,5 @@ moa:
   llm:
     gemini:
       api-key: ${MOA_LLM_GEMINI_API_KEY:dummy}
----
-spring:
-  config:
-    activate:
-      on-profile: test
-
-  flyway:
-    enabled: false
-
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
-  jpa:
-    hibernate:
-      ddl-auto: none
-
-moa:
-  llm:
-    gemini:
-      api-key: dummy
-      model: gemini-2.0-flash
 
 

--- a/src/test/java/com/moa/moa_backend/domain/digest/scheduler/StageDigestAutoRefreshSchedulerTest.java
+++ b/src/test/java/com/moa/moa_backend/domain/digest/scheduler/StageDigestAutoRefreshSchedulerTest.java
@@ -1,0 +1,49 @@
+package com.moa.moa_backend.domain.digest.scheduler;
+
+import com.moa.moa_backend.domain.digest.service.StageDigestService;
+import com.moa.moa_backend.domain.scrap.repository.ScrapDigestQueryRepository;
+import com.moa.moa_backend.domain.scrap.repository.projection.DigestRefreshTarget;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class StageDigestAutoRefreshSchedulerTest {
+
+    @Autowired
+    StageDigestAutoRefreshScheduler scheduler;
+
+    @MockitoBean
+    ScrapDigestQueryRepository scrapDigestQueryRepository;
+
+    @MockitoBean
+    StageDigestService stageDigestService;
+
+    @Test
+    void runDailyRefresh_calls_refresh_for_each_target() {
+        // given
+        List<DigestRefreshTarget> targets = List.of(
+                new DigestRefreshTarget(1L, 10L, "설계"),
+                new DigestRefreshTarget(1L, 10L, "구현")
+        );
+
+        when(scrapDigestQueryRepository.findRecentTargetsForAutoRefresh(any(), anyInt()))
+                .thenReturn(targets);
+
+        // when
+        scheduler.runDailyRefresh();
+
+        // then
+        verify(stageDigestService).refresh(1L, 10L, "설계");
+        verify(stageDigestService).refresh(1L, 10L, "구현");
+    }
+}


### PR DESCRIPTION
### 변경 사항 요약
- Stage Digest 자동 refresh 스케줄러 활성화
  - KST 기준 매일 04:00 1회 실행
  - 최근 활동한 (userId, projectId, stage) 기준 대상 선별
  - 하루 처리량 제한 적용
 
- Digest가 이미 최신인 경우 refresh 스킵
  - 스크랩 최신 시각과 digest 반영 시각 비교
  - 불필요한 LLM 호출 차단
 
- 수동/자동 refresh 공통 로직 정리
  - 단일 인스턴스 기준 in-flight 중복 호출 제어
  - 처리 중인 경우 409 DIGEST_REFRESH_IN_PROGRESS 반환
 
- 스케줄러 동작 검증 테스트 추가 